### PR TITLE
Fix exit node checkbox reverting state on error

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -561,14 +561,12 @@ class MainWindow(QMainWindow):
             self._last_exit_node_choice = node_to_set
             self._run_exit_node_command(
                 lambda: self.client.set_exit_node(node_to_set),
-                pending_state=(True, node_to_set),
-                on_error=lambda: self._set_exit_checkbox_checked(False)
+                pending_state=(True, node_to_set)
             )
         else:
             self._run_exit_node_command(
                 lambda: self.client.set_exit_node(None),
-                pending_state=(False, None),
-                on_error=lambda: self._set_exit_checkbox_checked(True)
+                pending_state=(False, None)
             )
 
     def _exit_node_changed(self, index: int):


### PR DESCRIPTION
The "Use exit node" checkbox was incorrectly reverting its state immediately upon interaction if the underlying `tailscale` command failed. This was due to `on_error` callbacks that were in a race condition with the main status refresh mechanism.

This change removes the redundant `on_error` callbacks from the `_run_exit_node_command` calls within the `_exit_use_changed` method. The UI now relies solely on the `refresh_status` function to reflect the true state of the exit node, providing a more stable and predictable user experience.